### PR TITLE
Fix missing base template

### DIFF
--- a/labtracker/templates/base.html
+++ b/labtracker/templates/base.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8" />
+  <title>{% block title %}Lab Tracker{% endblock %}</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+</head>
+<body class="container py-4">
+  {% block content %}{% endblock %}
+</body>
+</html>

--- a/labtracker/templates/case_detail.html
+++ b/labtracker/templates/case_detail.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block title %}케이스 {{ case.id }}{% endblock %}
 {% block content %}
 <h1>케이스 #{{ case.id }}</h1>
 


### PR DESCRIPTION
## Summary
- create a base template with Bootstrap included
- set page title in case_detail.html

## Testing
- `python -m compileall -q labtracker`

------
https://chatgpt.com/codex/tasks/task_e_685c08fc52dc832ab690d5482ba958cf