### PR TITLE
Implement file download API endpoint

### DIFF
--- a/labtracker/routes/cases.py
+++ b/labtracker/routes/cases.py
@@ -8,7 +8,7 @@ Case-related API endpoints.
 """
 
 from datetime import datetime
-from flask import request, jsonify
+from flask import request, jsonify, send_from_directory
 
 from . import bp
 from ..models import Case, ScanFile, db
@@ -109,3 +109,14 @@ def upload_file(case_id):
     db.session.add(sf)
     db.session.commit()
     return jsonify(sf.to_dict()), 201
+
+
+# ---------------------------------------------------------------------------
+#  파일 다운로드
+# ---------------------------------------------------------------------------
+@bp.route('/api/files/<int:file_id>/download')
+def download_file(file_id: int):
+    """저장된 스캔 파일을 클라이언트로 전송한다."""
+    sf = ScanFile.query.get_or_404(file_id)
+    file_path = Path('/app/data/uploads') / sf.filename
+    return send_from_directory(file_path.parent, file_path.name, as_attachment=True)


### PR DESCRIPTION
## Summary
- add `send_from_directory` import
- implement `/api/files/<file_id>/download` route to serve saved files

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c08fab4e8832a83cfa5020a25e1f5