### PR TITLE
Implement case detail data loading

### DIFF
--- a/labtracker/routes/web.py
+++ b/labtracker/routes/web.py
@@ -1,11 +1,27 @@
 from flask import Blueprint, render_template
 
+from ..models import Case
+from .cases import VALID_STATUSES
+
 ui_bp = Blueprint("ui", __name__)
 
 @ui_bp.route("/case/<int:case_id>", methods=["GET"])
 def case_detail(case_id):
     """브라우저에서 /case/<id> 요청 시 HTML 템플릿 반환."""
-    return render_template("case_detail.html", case_id=case_id)
+    case = Case.query.get_or_404(case_id)
+
+    status_choices = [
+        {"code": s, "label": s.replace("->", "→")}
+        for s in sorted(VALID_STATUSES)
+    ]
+
+    case.status_label = case.status.replace("->", "→")
+
+    return render_template(
+        "case_detail.html",
+        case=case,
+        status_choices=status_choices,
+    )
 
 @ui_bp.route("/cases")
 def case_list_page():


### PR DESCRIPTION
## Summary
- load Case instance in `case_detail`
- generate `status_choices` from API statuses
- return `case` and `status_choices` to the template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c1867e388832aaebb96fb759a3c8c