### PR TITLE
Implement status_label property

### DIFF
--- a/labtracker/models.py
+++ b/labtracker/models.py
@@ -17,6 +17,18 @@ class Case(db.Model):
     updated_at = db.Column(db.DateTime, default=datetime.utcnow,
                            onupdate=datetime.utcnow, nullable=False)
 
+    STATUS_LABELS = {
+        "SCANNED": "스캔→디자인",
+        "DESIGNING": "디자인→밀링",
+        "MILLING": "밀링→신터링&글레이징",
+        "DONE": "기공완료",
+    }
+
+    @property
+    def status_label(self) -> str:
+        """상태 코드에 대응하는 한글 라벨을 반환한다."""
+        return self.STATUS_LABELS.get(self.status, self.status)
+
     # files 역참조: case.files
 
     # ↓↓↓ 여기부터 메서드 추가 ↓↓↓

--- a/labtracker/routes/cases.py
+++ b/labtracker/routes/cases.py
@@ -59,6 +59,7 @@ def list_cases():
         {
             "id": r.id,
             "status": r.status,
+            "status_label": Case.STATUS_LABELS.get(r.status, r.status),
             "updated_at": r.updated_at.isoformat() if r.updated_at else None,
         }
         for r in rows
@@ -76,6 +77,7 @@ def get_case(case_id):
         {
             "id": row.id,
             "status": row.status,
+            "status_label": row.status_label,
             "updated_at": row.updated_at.isoformat() if row.updated_at else None,
         }
     ), 200

--- a/labtracker/templates/case_list.html
+++ b/labtracker/templates/case_list.html
@@ -49,7 +49,7 @@ async function fetchCases() {
       <tr>
         <td><input type="checkbox" value="${c.id}"></td>
         <td>${c.id}</td>
-        <td>${c.status}</td>
+        <td>${c.status_label ?? c.status}</td>
         <td>${c.updated_at ?? ''}</td>
       </tr>
     `);


### PR DESCRIPTION
## Summary
- map case status codes to user-friendly Korean labels
- expose `status_label` in case API responses
- show labels in the case list UI

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685c18684994832a84e3dee569214eae