### PR TITLE
Add status update API route

### DIFF
--- a/labtracker/routes/cases.py
+++ b/labtracker/routes/cases.py
@@ -81,6 +81,23 @@ def get_case(case_id):
     ), 200
 
 # ─────────────────────────────────────────────────────────────
+#  상태 PATCH /api/cases/<id>/status
+# ─────────────────────────────────────────────────────────────
+@bp.route("/api/cases/<int:case_id>/status", methods=["PATCH"])
+def update_status(case_id: int):
+    """단일 케이스의 상태를 변경한다."""
+    payload = request.get_json() or {}
+    new_status = payload.get("status")
+    if new_status not in VALID_STATUSES:
+        return jsonify({"msg": "invalid status"}), 400
+
+    case = Case.query.get_or_404(case_id)
+    case.status = new_status
+    case.updated_at = datetime.utcnow()
+    db.session.commit()
+    return jsonify({"status": case.status}), 200
+
+# ─────────────────────────────────────────────────────────────
 #  단일 케이스의 파일 목록  GET /api/cases/<id>/files
 # ─────────────────────────────────────────────────────────────
 @bp.route("/api/cases/<int:case_id>/files")

--- a/labtracker/static/js/case_detail.js
+++ b/labtracker/static/js/case_detail.js
@@ -8,8 +8,12 @@ document.addEventListener('DOMContentLoaded', () => {
       headers: { 'Content-Type': 'application/json' },
       body   : JSON.stringify({ status: code })
     });
-    if (res.ok) location.reload();
-    else alert('상태 변경 실패');
+    const result = await res.json();
+    if (res.ok) {
+      document.getElementById('current-status').textContent = result.status;
+    } else {
+      alert('상태 변경 실패');
+    }
   };
 
   // 라벨 재출력 (프린터 연결 전까지는 로그만)


### PR DESCRIPTION
## Summary
- add `/api/cases/<id>/status` PATCH endpoint
- update JS to reflect new endpoint response

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c18662f4c832a89506c08517fe6c3