### PR TITLE
Handle PollingObserver absence

### DIFF
--- a/labtracker/watcher.py
+++ b/labtracker/watcher.py
@@ -56,11 +56,19 @@ def start_watcher(app):
             obs.schedule(ScanHandler(app), str(watch_path), recursive=True)
             obs.start()
             app.logger.info("✅ inotify Observer started")
-        except Exception:
-            obs = PollingObserver(timeout=1.0)    # Fallback
-            obs.schedule(ScanHandler(app), str(watch_path), recursive=True)
-            obs.start()
-            app.logger.warning("⏱  Fallback to PollingObserver")
+        except Exception as exc:
+            if PollingObserver is None:
+                app.logger.error("❌ PollingObserver 사용 불가 – 감시 기능 비활성화")
+                app.logger.exception(exc)
+                return
+            try:
+                obs = PollingObserver(timeout=1.0)    # Fallback
+                obs.schedule(ScanHandler(app), str(watch_path), recursive=True)
+                obs.start()
+                app.logger.warning("⏱  Fallback to PollingObserver")
+            except Exception:
+                app.logger.exception("❌ PollingObserver 시작 실패")
+                raise
 
         obs.join()
 


### PR DESCRIPTION
## Summary
- improve start_watcher error handling when PollingObserver is unavailable

## Testing
- `pytest -q`
- `pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask==3.0.2)*

------
https://chatgpt.com/codex/tasks/task_e_685c1c4948a4832aa8c64a0157108b7d