### PR TITLE
Update status label logic

### DIFF
--- a/labtracker/models.py
+++ b/labtracker/models.py
@@ -17,17 +17,10 @@ class Case(db.Model):
     updated_at = db.Column(db.DateTime, default=datetime.utcnow,
                            onupdate=datetime.utcnow, nullable=False)
 
-    STATUS_LABELS = {
-        "SCANNED": "스캔→디자인",
-        "DESIGNING": "디자인→밀링",
-        "MILLING": "밀링→신터링&글레이징",
-        "DONE": "기공완료",
-    }
-
     @property
     def status_label(self) -> str:
-        """상태 코드에 대응하는 한글 라벨을 반환한다."""
-        return self.STATUS_LABELS.get(self.status, self.status)
+        """현재 상태 문자열을 화살표 기호로 변환하여 반환한다."""
+        return self.status.replace("->", "→")
 
     # files 역참조: case.files
 

--- a/labtracker/routes/cases.py
+++ b/labtracker/routes/cases.py
@@ -61,7 +61,7 @@ def list_cases():
         {
             "id": r.id,
             "status": r.status,
-            "status_label": Case.STATUS_LABELS.get(r.status, r.status),
+            "status_label": r.status.replace("->", "→"),
             "updated_at": r.updated_at.isoformat() if r.updated_at else None,
         }
         for r in rows

--- a/labtracker/routes/web.py
+++ b/labtracker/routes/web.py
@@ -15,8 +15,6 @@ def case_detail(case_id):
         for s in sorted(VALID_STATUSES)
     ]
 
-    case.status_label = case.status.replace("->", "→")
-
     return render_template(
         "case_detail.html",
         case=case,


### PR DESCRIPTION
## Summary
- simplify Case.status_label property
- update case API to produce label directly
- use status_label property in templates without override

## Testing
- `python -m labtracker.wsgi` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685c27397698832a98f691bd8c62ca02