### PR TITLE
Implement START_WATCHER env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,17 @@ lab-tracker/
 위와 같이 SCAN 폴더에 파일이 추가되면 워처가 자동으로 케이스를 생성하고
 라벨을 출력하게 됩니다.
 
+## 워처 실행 제어
+
+`START_WATCHER` 환경 변수를 `"1"`(기본값)로 두면 `start_watcher()`가 실행되어
+스캔 폴더를 감시합니다. 여러 워커를 사용하는 경우에는 중복 실행을 막기 위해
+한 워커에서만 `START_WATCHER=1`을 지정하고 나머지는 `0`으로 설정합니다. 예를
+들어 `docker-compose.yml`에서 첫 번째 컨테이너만 다음과 같이 지정합니다.
+
+```yaml
+environment:
+  - START_WATCHER=1
+```
+
+다른 워커 컨테이너에서는 `START_WATCHER=0`으로 설정하면 됩니다.
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - WATCH_PATH=/app/SCAN
       - PRINTER_NAME=Label
       - SITE_URL=https://labtracker.local
+      - START_WATCHER=1
 
     # ⬇︎ command 블록은 딱 한 번!
     command: >

--- a/labtracker/watcher.py
+++ b/labtracker/watcher.py
@@ -48,6 +48,10 @@ class ScanHandler(FileSystemEventHandler):
 
 # ── 2. 시작 함수 ───────────────────────────────────────────────
 def start_watcher(app):
+    if os.getenv("START_WATCHER", "1") != "1":
+        app.logger.info("START_WATCHER=0 → 워처 비활성화")
+        return
+
     watch_path = pathlib.Path(app.config["WATCH_PATH"])
 
     if not watch_path.exists():


### PR DESCRIPTION
## Summary
- respect `START_WATCHER` env var when starting the watcher
- enable the env var in `docker-compose.yml`
- document how to use `START_WATCHER` in README

## Testing
- `flake8` *(fails: command not found due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685c273a7c00832aa3712663994c8fdc