### PR TITLE
Add unique constraint to Case name

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ docker compose up --build
 
 환경 변수(스캔 폴더 위치, 프린터 이름 등)는 `docker-compose.yml`에서 수정할 수 있습니다.
 
+## DB 초기화 및 마이그레이션
+
+DB 파일은 `data/labtracker.db`에 생성됩니다. 스키마가 변경된 경우 기존 파일을 삭제하거나 아래 스크립트를 실행해 갱신할 수 있습니다.
+
+```bash
+# 새로 생성
+rm -f data/labtracker.db
+python -m labtracker.wsgi  # 최초 실행 시 테이블 자동 생성
+
+# 또는 마이그레이션 스크립트 사용
+python scripts/migrate_unique_case_name.py
+```
+
 ## 주요 엔드포인트
 
 - `GET /api/cases` – 케이스 목록 조회

--- a/labtracker/models.py
+++ b/labtracker/models.py
@@ -11,7 +11,7 @@ db = SQLAlchemy()
 class Case(db.Model):
     __tablename__ = 'case'
     id          = db.Column(db.Integer, primary_key=True)
-    name        = db.Column(db.String(128), nullable=False)
+    name        = db.Column(db.String(128), nullable=False, unique=True)
     status      = db.Column(db.String(32), nullable=False, default='스캔->디자인')
     created_at  = db.Column(db.DateTime, default=datetime.utcnow)
     updated_at = db.Column(db.DateTime, default=datetime.utcnow,

--- a/scripts/migrate_unique_case_name.py
+++ b/scripts/migrate_unique_case_name.py
@@ -1,0 +1,16 @@
+from labtracker.config import Config
+from labtracker.models import db
+from flask import Flask
+
+app = Flask(__name__)
+app.config.from_object(Config)
+
+db.init_app(app)
+with app.app_context():
+    # SQLite: 유니크 인덱스 추가 (존재하지 않으면)
+    db.session.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_case_name ON case (name)"
+    )
+    db.session.commit()
+    print("✅ idx_case_name unique index ensured")
+


### PR DESCRIPTION
## Summary
- ensure case names are unique
- add migration helper script
- document DB initialization and migration in README

## Testing
- `python -m py_compile labtracker/models.py scripts/migrate_unique_case_name.py`
- `./install.sh` *(fails: Wheel 'flask' ... invalid)*
- `PYTHONPATH=. python scripts/migrate_unique_case_name.py` *(fails: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685c273aae5c832abec1635cfdbf9f9b