### PR TITLE
update install script to use PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 1. 의존성 설치
    ```bash
-   pip install -r requirements.txt
+   ./install.sh  # 또는 `pip install -r requirements.txt`
    ```
 2. 서버 실행
    ```bash

--- a/install.sh
+++ b/install.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-pip install --no-index --find-links=vendor -r requirements.txt
+pip install --find-links=vendor -r requirements.txt


### PR DESCRIPTION
## Summary
- remove `--no-index` from `install.sh` so pip can fall back to PyPI
- update README install instructions

## Testing
- `python -m labtracker.wsgi` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685c2b43ed64832abd23f0a9447b1e5b