### PR TITLE
Handle missing lp command gracefully

### DIFF
--- a/labtracker/services.py
+++ b/labtracker/services.py
@@ -17,12 +17,19 @@ def save_case_and_print_label(case_name: str, stl_path: str):
     tmp = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
     qrcode.make(qr_data).save(tmp.name)
 
-    subprocess.run(
-        ["lp", "-d", app.config["PRINTER_NAME"], "-o", "fit-to-page", tmp.name],
-        check=False,
-    )
+    printed = True
+    try:
+        subprocess.run(
+            ["lp", "-d", app.config["PRINTER_NAME"], "-o", "fit-to-page", tmp.name],
+            check=False,
+        )
+    except FileNotFoundError:
+        printed = False
+        app.logger.warning("'lp' 명령을 찾을 수 없습니다. 라벨이 인쇄되지 않았습니다.")
 
     try:
         os.remove(tmp.name)
     except OSError:
         app.logger.warning("Could not remove temporary QR code file: %s", tmp.name)
+
+    return printed

--- a/labtracker/watcher.py
+++ b/labtracker/watcher.py
@@ -44,7 +44,9 @@ class ScanHandler(FileSystemEventHandler):
 
         from .services import save_case_and_print_label
         with self.app.app_context():
-            save_case_and_print_label(case_name, event.src_path)
+            success = save_case_and_print_label(case_name, event.src_path)
+            if not success:
+                self.app.logger.warning("라벨 인쇄에 실패했습니다: lp 명령을 찾을 수 없습니다.")
 
 # ── 2. 시작 함수 ───────────────────────────────────────────────
 def start_watcher(app):


### PR DESCRIPTION
## Summary
- handle FileNotFoundError in save_case_and_print_label
- return success flag from print routine and log warnings
- log warning in watcher if label printing fails

## Testing
- `python -m labtracker.wsgi` *(fails: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685c2b4f92e4832ab44ef9a250290cef