### PR TITLE
Fix install paths and remove vendor packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,7 @@ RUN apt-get update && \
 
 WORKDIR /app
 COPY requirements.txt .
-COPY vendor ./vendor
-RUN pip install --no-index --find-links=vendor -r requirements.txt
+RUN pip install -r requirements.txt
 
 COPY labtracker ./labtracker
 EXPOSE 5000

--- a/install.sh
+++ b/install.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-pip install --find-links=vendor -r requirements.txt
+pip install -r requirements.txt

--- a/vendor/Flask-3.0.2-py3-none-any.whl
+++ b/vendor/Flask-3.0.2-py3-none-any.whl
@@ -1,1 +1,0 @@
-Placeholder wheel for offline installation

--- a/vendor/Pillow-10.3.0-py3-none-any.whl
+++ b/vendor/Pillow-10.3.0-py3-none-any.whl
@@ -1,1 +1,0 @@
-Placeholder wheel for offline installation

--- a/vendor/qrcode-7.4.2-py3-none-any.whl
+++ b/vendor/qrcode-7.4.2-py3-none-any.whl
@@ -1,1 +1,0 @@
-Placeholder wheel for offline installation

--- a/vendor/watchdog-4.0.0-py3-none-any.whl
+++ b/vendor/watchdog-4.0.0-py3-none-any.whl
@@ -1,1 +1,0 @@
-Placeholder wheel for offline installation


### PR DESCRIPTION
## Summary
- pip install directly from PyPI in Dockerfile
- update install.sh to no longer reference vendor
- remove pre-bundled vendor wheels

## Testing
- `docker compose build` *(fails: `docker: command not found`)*
- `docker compose up` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685cac33fc18832aabff6faa1d3ca83d