### PR TITLE
Fix docker-compose path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - /volume1/SCAN:/app/SCAN:ro
 
       # 2) 코드·템플릿 실시간 반영
-      - /volume1/docker/lab-tracker/labtracker:/app/labtracker:rw
+      - ./labtracker:/app/labtracker:rw
 
       # 3) DB 파일
       - lab_tracker_data:/app/data


### PR DESCRIPTION
## Summary
- mount local `labtracker` source with a relative path in docker-compose

## Testing
- `python -m labtracker.wsgi` *(fails: ModuleNotFoundError - flask)*

------
https://chatgpt.com/codex/tasks/task_e_685cb200a270832a95ff1a5832a7e75f