### PR TITLE
Fix QR path and case navigation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN pip install -r requirements.txt
 
 COPY labtracker ./labtracker
 EXPOSE 5000
-CMD ["gunicorn", "-w", "1", "-b", "0.0.0.0:5000", "labtracker.wsgi:app"]
+CMD ["gunicorn", "-w", "2", "-b", "0.0.0.0:5000", "labtracker.wsgi:app"]

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ python scripts/migrate_unique_case_name.py
 - `GET /api/cases/<id>/files` – 케이스에 속한 파일 목록
 - `POST /api/cases/<id>/files` – 파일 업로드
 - `POST /api/cases/<id>/print_label` – 라벨 재출력
-- UI 페이지: `/cases`, `/case/<id>`
+- UI 페이지: `/cases`, `/cases/<id>`
 
 ## 워처 작동 방식
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
 
     # ⬇︎ command 블록은 딱 한 번!
     command: >
-      gunicorn --workers 1 --timeout 120 -b 0.0.0.0:5000 labtracker.wsgi:app
+      gunicorn --workers 2 --timeout 120 -b 0.0.0.0:5000 labtracker.wsgi:app
 
     # 📌  호스트 ↔ 컨테이너 디렉터리 매핑
     volumes:

--- a/labtracker/routes/web.py
+++ b/labtracker/routes/web.py
@@ -6,6 +6,7 @@ from .cases import VALID_STATUSES
 ui_bp = Blueprint("ui", __name__)
 
 @ui_bp.route("/case/<int:case_id>", methods=["GET"])
+@ui_bp.route("/cases/<int:case_id>", methods=["GET"])
 def case_detail(case_id):
     """브라우저에서 /case/<id> 요청 시 HTML 템플릿 반환."""
     case = Case.query.get_or_404(case_id)

--- a/labtracker/services.py
+++ b/labtracker/services.py
@@ -13,7 +13,8 @@ def save_case_and_print_label(case_name: str, stl_path: str):
 
     # ② 파일 추가 → models.py 의 add_file 메서드 호출
     case.add_file(stl_path)
-    qr_data = f"{app.config['SITE_URL']}/case/{case.id}"
+    # QR 코드 스캔 시 케이스 상세 페이지로 이동하도록 URL 경로 수정
+    qr_data = f"{app.config['SITE_URL']}/cases/{case.id}"
     tmp = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
     qrcode.make(qr_data).save(tmp.name)
 

--- a/labtracker/templates/case_list.html
+++ b/labtracker/templates/case_list.html
@@ -41,8 +41,8 @@ async function fetchCases() {
     tbody.insertAdjacentHTML('beforeend', `
       <tr>
         <td><input type="checkbox" value="${c.id}"></td>
-        <td>${c.id}</td>
-		<td>${c.name}</td>
+        <td><a href="/cases/${c.id}" class="text-decoration-none">${c.id}</a></td>
+        <td><a href="/cases/${c.id}" class="text-decoration-none">${c.name}</a></td>
         <td>${c.status_label ?? c.status}</td>
         <td>${c.updated_at ?? ''}</td>
       </tr>


### PR DESCRIPTION
## Summary
- QR 코드 URL이 `/cases/<id>`를 가리키도록 수정
- 케이스 목록에서 ID와 이름을 클릭하면 상세 페이지로 이동하게 변경
- `/cases/<id>` 경로에서도 케이스 상세 페이지가 열리도록 라우팅 추가
- gunicorn 워커 수를 2로 조정
- README 내 UI 경로 설명 업데이트

## Testing
- `python -m labtracker.wsgi` *(실패: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685cf7b307b8832aa7aaa657ccdfabc7