### PR TITLE
Update watch path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
     volumes:
       # 1) 스캔 폴더 (읽기 전용)
       - /volume1/SCAN:/app/SCAN:ro
+      - /volume1/3shape_orders:/app/3shape_orders:ro
 
       # 2) 코드·템플릿 실시간 반영
       - ./labtracker:/app/labtracker:rw

--- a/labtracker/watcher.py
+++ b/labtracker/watcher.py
@@ -12,6 +12,8 @@ except ImportError:
 
 import os, pathlib, re, time, threading
 
+SCAN_ROOT = pathlib.Path("/app/3shape_orders")
+
 # 파일명에서 케이스 이름을 추출하기 위한 패턴 (확장자 무관)
 CASE_REGEX = re.compile(r'^([^\s]+)\s+.*$', re.I)
 


### PR DESCRIPTION
## Summary
- switch watcher's scan root to `/app/3shape_orders`
- bind new `/volume1/3shape_orders` host volume

## Testing
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e0ebf04dc832ab6357a3a562dde41