### PR TITLE
update watch path

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ python scripts/init_db.py
 
 애플리케이션이 실행되면 `create_app()` 내부에서 `start_watcher()`가 호출되어
 주문 폴더 감시가 시작됩니다. 감시 대상 폴더는 환경 변수 `WATCH_PATH`로 지정하며
-기본값은 `/volume1/3shape_orders`입니다. 폴더가 존재하지 않으면 시작 시 자동으로
+기본값은 `/volume1/3shape_orders/3Shape Dental System Orders`입니다. 폴더가 존재하지 않으면 시작 시 자동으로
 생성됩니다.
 
 워처는 `watchdog` 라이브러리의 `Observer`(inotify)를 우선 사용하고, 실패할 경우

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
 
     environment:
       - FLASK_ENV=production
-      - WATCH_PATH=/volume1/3shape_orders
+      - WATCH_PATH="/volume1/3shape_orders/3Shape Dental System Orders"
       - PRINTER_NAME=Label
       - SITE_URL=http://192.168.0.123:15000
       - START_WATCHER=1
@@ -24,7 +24,7 @@ services:
     volumes:
       # 1) 스캔 폴더 (읽기 전용)
       - /volume1/SCAN:/app/SCAN:ro
-      - /volume1/3shape_orders:/volume1/3shape_orders:ro
+      - "/volume1/3shape_orders/3Shape Dental System Orders:/volume1/3shape_orders/3Shape Dental System Orders:ro"
 
       # 2) 코드·템플릿 실시간 반영
       - ./labtracker:/app/labtracker:rw

--- a/labtracker/config.py
+++ b/labtracker/config.py
@@ -7,6 +7,9 @@ class Config:
     )
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 
-    WATCH_PATH = os.getenv("WATCH_PATH", "/volume1/3shape_orders")
+    WATCH_PATH = os.getenv(
+        "WATCH_PATH",
+        "/volume1/3shape_orders/3Shape Dental System Orders",
+    )
     PRINTER_NAME = os.getenv("PRINTER_NAME", "Label")
     SITE_URL = os.getenv("SITE_URL", "http://localhost:15000")


### PR DESCRIPTION
## Summary
- adjust default `WATCH_PATH` to point to the `3Shape Dental System Orders` directory
- update documentation and docker settings accordingly

## Testing
- `python -m labtracker.wsgi` *(fails: No module named 'flask')*
- `pip install flake8` *(fails due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6865d8e610b4832a9f9960a763bd4ecb