### PR TITLE
Fix WATCH_PATH format

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,11 +10,11 @@ services:
       - "15000:5000"
 
     environment:
-      - FLASK_ENV=production
-      - WATCH_PATH="/volume1/3shape_orders/3Shape Dental System Orders"
-      - PRINTER_NAME=Label
-      - SITE_URL=http://192.168.0.123:15000
-      - START_WATCHER=1
+      FLASK_ENV: production
+      WATCH_PATH: /volume1/3shape_orders/3Shape Dental System Orders
+      PRINTER_NAME: Label
+      SITE_URL: http://192.168.0.123:15000
+      START_WATCHER: 1
 
     # ⬇︎ command 블록은 딱 한 번!
     command: >


### PR DESCRIPTION
## Summary
- clean up `docker-compose.yml` environment block to use YAML mapping

## Testing
- `python -m labtracker.wsgi` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install -r requirements.txt` *(fails: Could not establish connection)*

------
https://chatgpt.com/codex/tasks/task_e_6865fac91200832a8aa999e1ad7bc77f