### PR TITLE
Initialize database with existing folders on startup

### DIFF
--- a/labtracker/watcher.py
+++ b/labtracker/watcher.py
@@ -110,6 +110,9 @@ def start_watcher(app):
             app.logger.warning("🚫  WATCH_PATH '%s' not found: %s", watch_path, e)
             return
 
+    # 서버 시작 직후 기존 폴더들을 한 번 스캔하여 DB에 등록한다
+    rescan_all(app)
+
     def _run():
         try:
             obs = Observer()


### PR DESCRIPTION
## Summary
- rescan existing case folders before starting the watcher

## Testing
- `flake8` *(fails: command not found)*
- `python -m labtracker.wsgi` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6865faca7398832a976a591614ed829f